### PR TITLE
Fix Removing Circles and Polygons

### DIFF
--- a/resources/views/components/map.blade.php
+++ b/resources/views/components/map.blade.php
@@ -373,7 +373,7 @@
                     if (tooltip) {
                         cCircle.bindTooltip(tooltip);
                     }
-                    this.circles.push({id, marker: cCircle});
+                    this.circles.push({id, circle: cCircle});
                 },
                 removeMarker: function (id) {
                     const m = this.markers.find(m => m.id === id);
@@ -392,7 +392,7 @@
                 removePolygone: function (id) {
                     const p = this.polygones.find(p => p.id === id);
                     if (p) {
-                        p.polygones.remove();
+                        p.polygon.remove();
                         this.polygones = this.polygones.filter(p => p.id !== id);
                     }
                 },


### PR DESCRIPTION
## Issue:

We have noticed that removing circles and polygons doesn't work as there's a mismatch on the property names.

For circles, the pushed object to `this.circles` currently contains the keys `id` and `marker` whereas it should be `id` and `circle` based on what the `removeCircle` method expects. I have changed it to push an object containing `id` and `circle`.

For polygons/polygones, the pushed object to `this.polygones` contains the keys `id` and `polygon` whereas the `removePolygone` method expects the property on the object to be called `polygones`. I have changed `removePolygone` to expect `polygon` instead of `polygones`, as it's a singular context.

## Breaking Changes:
This shouldn't introduce any breaking changes, as from what I can tell, these property names are only used when removing polygons and circles.